### PR TITLE
♻️ Harden name matching, dedupe setState

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,5 +19,6 @@ jobs:
         with:
           channel: 'stable'
       - run: flutter pub get
+      - run: dart format --set-exit-if-changed .
       - run: flutter analyze
       - run: flutter test

--- a/lib/src/models/selection_model.dart
+++ b/lib/src/models/selection_model.dart
@@ -2,6 +2,11 @@ class SelectionModel {
   String? code;
   String? name;
   String? regionCode;
+
+  /// `dynamic`, not `String?`, because `city.json` encodes "no province"
+  /// (NCR-style cities that belong directly to a region) as boolean `false`
+  /// rather than `null`/absent. `_applyProvince`'s NCR-flattening comparison
+  /// relies on this — do not tighten the type without updating that logic.
   dynamic provinceCode;
 
   SelectionModel({this.code, this.name, this.regionCode, this.provinceCode});

--- a/lib/src/psgc_picker.dart
+++ b/lib/src/psgc_picker.dart
@@ -26,8 +26,23 @@ class PsgcPicker extends StatefulWidget {
   /// (required) returns a function with string value from [city] selection
   final ValueChanged<String> onCityChanged;
 
+  /// Initial region selection, given as a **name** (not a code), e.g.
+  /// `'Ilocos Region'`. Matching against the loaded dataset is
+  /// case-insensitive and trims leading/trailing whitespace. A name that
+  /// doesn't match any entry silently leaves the region (and downstream
+  /// province/city) unselected — it does not throw.
   final String selectedRegion;
+
+  /// Initial province selection, given as a **name** (not a code). Same
+  /// case-insensitive, trimmed matching and silent-no-op-on-mismatch
+  /// behavior as [selectedRegion]. Only applied if [selectedRegion] itself
+  /// resolves to a match.
   final String selectedProvince;
+
+  /// Initial city/municipality selection, given as a **name** (not a code).
+  /// Same case-insensitive, trimmed matching and silent-no-op-on-mismatch
+  /// behavior as [selectedRegion]. Only applied if [selectedProvince] itself
+  /// resolves to a match.
   final String selectedCity;
 
   const PsgcPicker(
@@ -85,19 +100,20 @@ class _PsgcPickerState extends State<PsgcPicker> {
       _region = _regionList;
       var selectRegion = _region.firstWhere(
           (element) =>
-              element.name == widget.selectedRegion.toUpperCase(),
+              element.name == widget.selectedRegion.trim().toUpperCase(),
           orElse: () => SelectionModel());
       if (selectRegion.code != null) {
         _applyRegion(selectRegion.code!);
 
         var selectProvince = _province.firstWhere(
             (element) =>
-                element.name == widget.selectedProvince.toUpperCase(),
+                element.name == widget.selectedProvince.trim().toUpperCase(),
             orElse: () => SelectionModel());
         if (selectProvince.code != null) _applyProvince(selectProvince.code!);
 
         var selectCity = _city.firstWhere(
-            (element) => element.name == widget.selectedCity.toUpperCase(),
+            (element) =>
+                element.name == widget.selectedCity.trim().toUpperCase(),
             orElse: () => SelectionModel());
         if (selectCity.code != null) _applyCity(selectCity.code!);
       }
@@ -116,8 +132,11 @@ class _PsgcPickerState extends State<PsgcPicker> {
           .where((element) => element.regionCode == value)
           .toList();
       if (_province.isEmpty) {
+        // NCR-style region with no distinct provinces: treat the region
+        // itself as the sole "province" entry and cascade straight into it,
+        // without nesting another setState inside this one.
         _province = _region.where((element) => element.code == value).toList();
-        _applyProvince(value);
+        _selectProvince(value);
       }
       var selected = _region.firstWhere((element) => element.code == value,
           orElse: () => SelectionModel());
@@ -127,18 +146,20 @@ class _PsgcPickerState extends State<PsgcPicker> {
 
   void _applyProvince(String value) {
     if (!mounted) return;
-    setState(() {
-      _selectedProvinceCode = value;
-      _selectedCityCode = null;
-      _city.clear();
-      _city = _cityList
-          .where((element) =>
-              element.provinceCode == value || element.regionCode == value)
-          .toList();
-      var selected = _province.firstWhere((element) => element.code == value,
-          orElse: () => SelectionModel());
-      if (selected.name != null) widget.onProvinceChanged(selected.name!);
-    });
+    setState(() => _selectProvince(value));
+  }
+
+  void _selectProvince(String value) {
+    _selectedProvinceCode = value;
+    _selectedCityCode = null;
+    _city.clear();
+    _city = _cityList
+        .where((element) =>
+            element.provinceCode == value || element.regionCode == value)
+        .toList();
+    var selected = _province.firstWhere((element) => element.code == value,
+        orElse: () => SelectionModel());
+    if (selected.name != null) widget.onProvinceChanged(selected.name!);
   }
 
   void _applyCity(String value) {

--- a/lib/src/widgets/psgc_dropdown_widget.dart
+++ b/lib/src/widgets/psgc_dropdown_widget.dart
@@ -24,8 +24,8 @@ class PsgcDropdownWidget extends StatelessWidget {
           child: DropdownButton<String>(
         isExpanded: true,
         items: selection
-            .map((SelectionModel item) =>
-                DropdownMenuItem(value: item.code, child: Text(item.name!)))
+            .map((SelectionModel item) => DropdownMenuItem(
+                value: item.code, child: Text(item.name ?? '')))
             .toList(),
         onChanged: (value) => onSelectionChanged(value!),
         value: selectedValue,

--- a/test/psgc_picker_test.dart
+++ b/test/psgc_picker_test.dart
@@ -97,8 +97,7 @@ void main() {
     expect(itemCodes(province), unorderedEquals(_ilocosProvinceCodes));
   });
 
-  testWidgets('selecting a province filters the city dropdown',
-      (tester) async {
+  testWidgets('selecting a province filters the city dropdown', (tester) async {
     await pumpPicker(tester);
 
     dropdowns(tester)[0].onChanged!(_ilocosRegionCode);


### PR DESCRIPTION
## :pushpin: Thread or Issue
N/A

## :memo: Summary of Changes
Trims and case-normalizes the initial `selectedRegion`/`selectedProvince`/`selectedCity` name lookups, removes the nested `setState` in the NCR region-as-province fallback path (`_selectProvince` now runs plain state mutation, wrapped in `setState` only at the outer call site), removes an unsafe force-unwrap in the dropdown item builder, adds dartdoc for the public selection params and `SelectionModel.provinceCode`'s `dynamic` type, and adds a `dart format --set-exit-if-changed` step to CI.