### PR TITLE
🔖 Bump version to 1.0.3 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.0.3
+### What's Changed
+- Widened Dart SDK constraint to support Dart 3 (previously capped below 3.0.0)
+- Hardened asset loading: a failed/malformed JSON load now surfaces as an inline error instead of throwing
+- Guarded lookups against unmatched selections instead of throwing (e.g. `firstWhere` on no match)
+- Case-insensitive, whitespace-trimmed matching for initial `selectedRegion`/`selectedProvince`/`selectedCity` names, with a `mounted` guard around the async initial-selection flow
+- Deduplicated redundant `setState` calls during cascading selection
+- Added a real widget test suite (previously untested) and CI workflow
+- Corrected package description/README to accurately reflect scope (dropped the inaccurate "municipality, and barangay" claim)
+- Bumped `flutter_lints` to 6.x and trimmed non-source files from the published package via `.pubignore`
+
 ## 1.0.2
 ### What's Changed
 Added selected values and uppercase text selection

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## PSGC Picker
 
-This package is used for listing all the region, province, city, municipality, and barangay. Philippine Standard Geographic Codes
+This package is used for listing all the region, province, and city/municipality. Philippine Standard Geographic Codes
 
 ## Installation
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -145,7 +145,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.2"
+    version: "1.0.3"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: psgc_picker
-description: This package is used for listing all the region, province, city, municipality, and barangay. Philippine Standard Geographic Codes
-version: 1.0.2
+description: This package is used for listing all the region, province, and city/municipality. Philippine Standard Geographic Codes
+version: 1.0.3
 maintainer: Neil Cabug-os (@neilcabugos)
 repository: https://github.com/neilcabugos/psgc_picker
 issue_tracker: https://github.com/neilcabugos/psgc_picker/issues


### PR DESCRIPTION
## :pushpin: Thread or Issue
N/A — surfaced during a pre-publish audit: version 1.0.2 is already live on pub.dev, but several hardening/testing commits have landed on `main` since then without a version bump.

## :memo: Summary of Changes
- Bump `pubspec.yaml` version `1.0.2` → `1.0.3` (republishing 1.0.2 as-is would be rejected by pub.dev)
- Add a `## 1.0.3` CHANGELOG entry covering the SDK constraint widening, asset-loading/lookup hardening, case-insensitive initial-selection matching, dedup'd `setState`, and the new test suite/CI
- Correct the package description and README, which claimed municipality/barangay-level support that was never implemented (only region/province/city)

## :white_check_mark: Test Plan
- [x] `dart format --set-exit-if-changed .`
- [x] `flutter analyze`
- [x] `flutter test`
- [x] `dart pub publish --dry-run`