### PR TITLE
⬆️ Upgrade flutter_lints to 6.x and trim published package

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,0 +1,7 @@
+# Internal project files - not relevant to package consumers.
+CLAUDE.md
+
+# Generated build artifacts - already in .gitignore, but a .pubignore file
+# switches pub's file selection to walk the full tree, so list explicitly.
+build/
+.dart_tool/

--- a/lib/src/psgc_picker.dart
+++ b/lib/src/psgc_picker.dart
@@ -56,8 +56,7 @@ class PsgcPicker extends StatefulWidget {
       this.regionLabel,
       this.provinceLabel,
       this.cityLabel,
-      Key? key})
-      : super(key: key);
+      super.key});
 
   @override
   State<PsgcPicker> createState() => _PsgcPickerState();

--- a/lib/src/widgets/psgc_dropdown_widget.dart
+++ b/lib/src/widgets/psgc_dropdown_widget.dart
@@ -13,8 +13,7 @@ class PsgcDropdownWidget extends StatelessWidget {
       required this.selectedValue,
       this.decoration =
           const InputDecoration(contentPadding: EdgeInsets.all(0.0)),
-      Key? key})
-      : super(key: key);
+      super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.0
+  flutter_lints: ^6.0.0
 
 flutter:
 


### PR DESCRIPTION
## :pushpin: Thread or Issue
N/A — split out from the pre-publish audit alongside #16 as an independent chore.

## :memo: Summary of Changes
- Bump `flutter_lints` `^2.0.0` → `^6.0.0` in `pubspec.yaml`
- Adopt the new `use_super_parameters` lint (`Key? key` / `super(key: key)` → `super.key`) in `PsgcPicker` and `PsgcDropdownWidget` to keep `flutter analyze` clean under the new lint set
- Add `.pubignore` to exclude internal project files and generated build artifacts from the published pub.dev archive

## :white_check_mark: Test Plan
- [x] `dart format --set-exit-if-changed .`
- [x] `flutter analyze`
- [x] `flutter test`
- [x] `dart pub publish --dry-run` (confirms `.pubignore` trims the archive as expected)