### PR TITLE
📝 Document styling options for PsgcPicker in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,43 @@ class _MyFormState extends State<MyForm> {
 
 ![Region, province, and city fields sharing a PsgcPickerController while rendered in separate cards](screenshots/standalone_fields.png)
 
+### Styling
+
+Each field (`regionLabel`/`regionDecoration`, `provinceLabel`/`provinceDecoration`, `cityLabel`/`cityDecoration` on `PsgcPicker`; `label`/`decoration` on `PsgcRegionField`, `PsgcProvinceField`, `PsgcCityField`) accepts either:
+
+- a plain `String` label — wrapped internally as `InputDecoration(labelText: label)`, or
+- a full `InputDecoration` — for control over borders, fill color, icons, hint text, error text, etc. When both are supplied, `decoration` takes precedence over `label`.
+
+`spacing` on `PsgcPicker` controls the vertical gap between the three dropdowns.
+
+```dart
+PsgcPicker(
+  regionDecoration: const InputDecoration(
+    labelText: 'Region',
+    prefixIcon: Icon(Icons.map_outlined),
+    border: OutlineInputBorder(),
+    filled: true,
+  ),
+  provinceDecoration: const InputDecoration(
+    labelText: 'Province',
+    border: OutlineInputBorder(),
+  ),
+  cityDecoration: const InputDecoration(
+    labelText: 'City/Municipality',
+    border: OutlineInputBorder(),
+  ),
+  spacing: 12,
+  selectedRegion: 'CALABARZON',
+  selectedProvince: 'RIZAL',
+  selectedCity: 'CAINTA',
+  onRegionChanged: (value) => {},
+  onProvinceChanged: (value) => {},
+  onCityChanged: (value) => {},
+)
+```
+
+The same `decoration` parameter works identically on the standalone `PsgcRegionField`/`PsgcProvinceField`/`PsgcCityField` widgets.
+
 ## Notes
 
 If the data is outdate, feel free to create issue. Thank you


### PR DESCRIPTION
## :pushpin: Thread or Issue
N/A

## :memo: Summary of Changes
- Add a "Styling" section to README.md documenting the `label`/`decoration` parameters on `PsgcPicker` (and the standalone `PsgcRegionField`/`PsgcProvinceField`/`PsgcCityField` widgets), including that `decoration` takes precedence over `label`
- Document the `spacing` parameter on `PsgcPicker`
- Include a runnable example using `InputDecoration` (border, fill, prefix icon)

## :white_check_mark: Test Plan
- [x] Docs-only change; no code touched
- [x] Reviewed rendered markdown for formatting/syntax correctness