### PR TITLE
ci: bump release-please-action to v5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           config-file: release-config.json
           manifest-file: .release-manifest.json


### PR DESCRIPTION
## :pushpin: Thread or Issue

N/A

## :memo: Summary of Changes

- Bump `googleapis/release-please-action` from `v4` to `v5` in `.github/workflows/release.yml`. The only breaking change in v5 is an internal Node24 runtime upgrade for the action itself (transparent on GitHub-hosted runners) — no config or input changes needed.

## :white_check_mark: Test Plan

- [x] Reviewed v5 release notes for breaking changes affecting `config-file`/`manifest-file` inputs (none)
- [ ] Confirm `release-please` workflow runs successfully on next push to `main`