### PR TITLE
fix: guard notifyListeners with disposed check in selectors

### DIFF
--- a/lib/src/psgc_picker_controller.dart
+++ b/lib/src/psgc_picker_controller.dart
@@ -148,7 +148,7 @@ class PsgcPickerController extends ChangeNotifier {
   /// Returns the resolved region name, if any.
   String? selectRegion(String value) {
     var name = _selectRegionInternal(value);
-    notifyListeners();
+    if (!_disposed) notifyListeners();
     return name;
   }
 
@@ -170,7 +170,7 @@ class PsgcPickerController extends ChangeNotifier {
   /// downstream city selection. Returns the resolved province name, if any.
   String? selectProvince(String value) {
     var name = _selectProvinceInternal(value);
-    notifyListeners();
+    if (!_disposed) notifyListeners();
     return name;
   }
 
@@ -185,7 +185,7 @@ class PsgcPickerController extends ChangeNotifier {
   /// Selects a city by code. Returns the resolved city name, if any.
   String? selectCity(String value) {
     var name = _selectCityInternal(value);
-    notifyListeners();
+    if (!_disposed) notifyListeners();
     return name;
   }
 


### PR DESCRIPTION
## :pushpin: Thread or Issue

N/A

## :memo: Summary of Changes

- `selectRegion`, `selectProvince`, and `selectCity` in `PsgcPickerController` now guard `notifyListeners()` with an `if (!_disposed)` check, matching the pattern already used in `_load()`.
- Without this, calling a selector after the controller is disposed throws `A ChangeNotifier was used after being disposed` in debug builds — a real risk since the controller is documented as safely shareable across independently-placed field widgets.

## :white_check_mark: Test Plan

- [x] `flutter analyze` — no issues
- [x] `flutter test` — all tests pass