### PR TITLE
fix: validate selector codes against current list

### DIFF
--- a/lib/src/psgc_picker_controller.dart
+++ b/lib/src/psgc_picker_controller.dart
@@ -145,8 +145,10 @@ class PsgcPickerController extends ChangeNotifier {
   /// Selects a region by code, filtering [provinceList] (or cascading
   /// straight to [cityList] for NCR-style regions with no distinct
   /// provinces) and clearing any downstream province/city selection.
-  /// Returns the resolved region name, if any.
+  /// Returns the resolved region name, if any. If [value] doesn't match any
+  /// entry in [regionList], this is a no-op and returns `null`.
   String? selectRegion(String value) {
+    if (!_region.any((element) => element.code == value)) return null;
     var name = _selectRegionInternal(value);
     if (!_disposed) notifyListeners();
     return name;
@@ -168,7 +170,10 @@ class PsgcPickerController extends ChangeNotifier {
 
   /// Selects a province by code, filtering [cityList] and clearing any
   /// downstream city selection. Returns the resolved province name, if any.
+  /// If [value] doesn't match any entry in [provinceList], this is a no-op
+  /// and returns `null`.
   String? selectProvince(String value) {
+    if (!_province.any((element) => element.code == value)) return null;
     var name = _selectProvinceInternal(value);
     if (!_disposed) notifyListeners();
     return name;
@@ -182,8 +187,11 @@ class PsgcPickerController extends ChangeNotifier {
     return selected.name;
   }
 
-  /// Selects a city by code. Returns the resolved city name, if any.
+  /// Selects a city by code. Returns the resolved city name, if any. If
+  /// [value] doesn't match any entry in [cityList], this is a no-op and
+  /// returns `null`.
   String? selectCity(String value) {
+    if (!_city.any((element) => element.code == value)) return null;
     var name = _selectCityInternal(value);
     if (!_disposed) notifyListeners();
     return name;

--- a/test/psgc_picker_controller_test.dart
+++ b/test/psgc_picker_controller_test.dart
@@ -197,4 +197,43 @@ void main() {
     await tester.runAsync(
         () => Future<void>.delayed(const Duration(milliseconds: 100)));
   });
+
+  testWidgets(
+      'selecting an unknown/stale code is a no-op that leaves state '
+      'unchanged', (tester) async {
+    final regionChanges = <String>[];
+    final provinceChanges = <String>[];
+    final cityChanges = <String>[];
+    late PsgcPickerController controller;
+    await tester.runAsync(() async {
+      controller = PsgcPickerController(
+        onRegionChanged: regionChanges.add,
+        onProvinceChanged: provinceChanges.add,
+        onCityChanged: cityChanges.add,
+      );
+      await controller.load();
+      controller.selectRegion(_ilocosRegionCode);
+      controller.selectProvince(_ilocosNorteCode);
+      controller.selectCity(_adamsCode);
+    });
+    regionChanges.clear();
+    provinceChanges.clear();
+    cityChanges.clear();
+
+    var notifyCount = 0;
+    controller.addListener(() => notifyCount++);
+
+    expect(controller.selectRegion('not-a-real-code'), isNull);
+    expect(controller.selectProvince('not-a-real-code'), isNull);
+    expect(controller.selectCity('not-a-real-code'), isNull);
+
+    expect(notifyCount, 0);
+    expect(regionChanges, isEmpty);
+    expect(provinceChanges, isEmpty);
+    expect(cityChanges, isEmpty);
+    expect(controller.selectedRegionCode, _ilocosRegionCode);
+    expect(controller.selectedProvinceCode, _ilocosNorteCode);
+    expect(controller.selectedCityCode, _adamsCode);
+    controller.dispose();
+  });
 }


### PR DESCRIPTION
## :pushpin: Thread or Issue

N/A

## :memo: Summary of Changes

- `selectRegion`, `selectProvince`, and `selectCity` in `PsgcPickerController` now validate the incoming code against the current `regionList`/`provinceList`/`cityList` before accepting it.
- Previously, a stale/typo'd code was accepted and stored with no matching list entry, which later caused `DropdownButton` to throw an assertion failure at *build* time — far from the actual bad input.
- An unknown code is now a no-op: state is left unchanged, no `onXChanged` callback fires, `notifyListeners()` is not called, and the method returns `null`.
- Added a test covering all three selectors with an unknown/stale code.

## :white_check_mark: Test Plan

- [x] `dart format --set-exit-if-changed .` — no diff
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all tests pass, including the new unknown-code coverage