### PR TITLE
fix: make load() idempotent after a successful completion

### DIFF
--- a/lib/src/psgc_picker_controller.dart
+++ b/lib/src/psgc_picker_controller.dart
@@ -55,6 +55,7 @@ class PsgcPickerController extends ChangeNotifier {
   String? _selectedCityCode;
 
   bool _isLoading = false;
+  bool _loaded = false;
   Future<void>? _inFlightLoad;
   Object? _loadError;
   bool _disposed = false;
@@ -79,9 +80,14 @@ class PsgcPickerController extends ChangeNotifier {
 
   /// Loads the bundled region/province/city datasets and applies the
   /// initial [selectedRegion]/[selectedProvince]/[selectedCity], if given.
-  /// Safe to call more than once; a call made while a load is already in
-  /// flight awaits that same load rather than starting a second one.
+  /// Idempotent: a call made while a load is already in flight awaits that
+  /// same load rather than starting a second one, and a call made after a
+  /// previous load already completed *successfully* is a no-op — it will
+  /// not re-parse the datasets or re-apply the initial selections over any
+  /// selections made since. If the previous load failed (see [loadError]),
+  /// a further call retries it from scratch.
   Future<void> load() {
+    if (_loaded) return Future.value();
     return _inFlightLoad ??= _load().whenComplete(() => _inFlightLoad = null);
   }
 
@@ -119,6 +125,7 @@ class PsgcPickerController extends ChangeNotifier {
     }
 
     _isLoading = false;
+    _loaded = true;
     if (!_disposed) notifyListeners();
   }
 

--- a/test/psgc_picker_controller_test.dart
+++ b/test/psgc_picker_controller_test.dart
@@ -236,4 +236,34 @@ void main() {
     expect(controller.selectedCityCode, _adamsCode);
     controller.dispose();
   });
+
+  testWidgets(
+      'calling load() again after a successful load is a no-op that '
+      'preserves selections made since', (tester) async {
+    final regionChanges = <String>[];
+    late PsgcPickerController controller;
+    await tester.runAsync(() async {
+      controller = PsgcPickerController(
+        selectedRegion: _ilocosRegionName,
+        onRegionChanged: regionChanges.add,
+      );
+      await controller.load();
+      // A selection made after the initial load resolves.
+      controller.selectRegion(_cagayanValleyRegionCode);
+    });
+    regionChanges.clear();
+
+    var notifyCount = 0;
+    controller.addListener(() => notifyCount++);
+
+    await tester.runAsync(() => controller.load());
+
+    expect(notifyCount, 0);
+    expect(regionChanges, isEmpty);
+    // Still the region selected after load, not selectedRegion reapplied.
+    expect(controller.selectedRegionCode, _cagayanValleyRegionCode);
+    expect(controller.provinceList.map((e) => e.code),
+        unorderedEquals(_cagayanValleyProvinceCodes));
+    controller.dispose();
+  });
 }


### PR DESCRIPTION
## :pushpin: Thread or Issue

N/A

## :memo: Summary of Changes

- `PsgcPickerController.load()` now tracks whether a prior load already succeeded. If so, a further call is a true no-op — it returns immediately without re-parsing the bundled JSON datasets or re-applying the constructor's `selectedRegion`/`selectedProvince`/`selectedCity`, so any selections made since are preserved.
- If the prior load ended in `loadError`, the next `load()` call still retries from scratch (nothing to preserve in that case).
- In-flight calls are still coalesced into the same future, unchanged from before.
- Added a test covering that a second `load()` call after success preserves a selection made in between.

## :white_check_mark: Test Plan

- [x] `dart format --set-exit-if-changed .` — no diff
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all tests pass, including the new coverage