### PR TITLE
docs: add Changelog header for release-please anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## 1.1.0
 ### What's Changed
 - Added `PsgcPickerController`, which owns PSGC data loading and cascading selection state independently of any particular widget layout


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits so release-please can parse it:
  type: short summary
e.g. "feat: Add decoration pass-through to PsgcPicker"
Allowed types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
-->

## :pushpin: Thread or Issue
Fixes the changelog ordering issue reported in #24: the release-please PR inserted the new `1.1.1` section below `1.1.0` instead of above it, breaking descending version order.

## :memo: Summary of Changes
- Added a `# Changelog` title line to the top of `CHANGELOG.md`.
- `CHANGELOG.md` has always been hand-maintained (no `# Changelog` header, no `x-release-please-start/end` markers) — this is the first PR release-please has generated for it, and without a header to anchor on it inserted the new release section in the wrong place.
- With the header in place, release-please should anchor future insertions at the top of the file, in correct descending version order.

## Test Plan
- [ ] Merge this PR, then trigger the release-please workflow (push to `main`) and confirm PR #24 (or its successor) is regenerated with `1.1.1` inserted above `1.1.0`.