### PR TITLE
fix: use plain version tags/release names for release-please

### DIFF
--- a/release-config.json
+++ b/release-config.json
@@ -3,7 +3,8 @@
   "packages": {
     ".": {
       "release-type": "dart",
-      "package-name": "psgc_picker"
+      "include-v-in-tag": false,
+      "include-v-in-release-name": false
     }
   }
 }


### PR DESCRIPTION
## :pushpin: Thread or Issue
N/A

## :memo: Summary of Changes
- Drop `package-name` and set `include-v-in-tag`/`include-v-in-release-name` to `false` in `release-config.json`
- Restores the repo's pre-existing plain-number tag/release convention (e.g. `1.1.0`, `1.0.3`) instead of the component-prefixed `psgc_picker: v1.1.1` produced by the first release-please run

## Test plan
- [ ] Confirm the next release-please PR/release produces a tag/title like `1.1.2` with no `v` or `psgc_picker` prefix