### PR TITLE
fix: exclude package-name component from release-please tags

### DIFF
--- a/release-config.json
+++ b/release-config.json
@@ -4,7 +4,8 @@
     ".": {
       "release-type": "dart",
       "include-v-in-tag": false,
-      "include-v-in-release-name": false
+      "include-v-in-release-name": false,
+      "include-component-in-tag": false
     }
   }
 }


### PR DESCRIPTION
## :pushpin: Thread or Issue
Follow-up to #28 / #29.

## :memo: Summary of Changes
`release-config.json` still produced tags and CHANGELOG compare links prefixed with the package name (e.g. `psgc_picker-1.1.2`), even though `package-name` was removed from the config in #28. `release-type: dart` derives the component from `pubspec.yaml`'s `name` field regardless of that setting, and `include-component-in-tag` defaults to `true` whenever a component exists.

Adds `"include-component-in-tag": false` to `release-config.json` so future tags/release names/compare links use plain versions only (e.g. `1.1.2` instead of `psgc_picker-1.1.2`).

## Test plan
- [x] Validated `release-config.json` is well-formed JSON
- [x] Confirm the next release-please run produces a plain-version tag and a CHANGELOG compare link with no `psgc_picker-` prefix